### PR TITLE
fix: [GRASSHOPPER-7176] Add docker compatibility to our fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@
 
 source 'https://rubygems.org'
 
-gem 'berkshelf'
+gem "berkshelf", "~> 7.0"
 gem 'poise', '~> 2.2'
 gem 'poise-boiler'
 gem 'poise-service', '~> 1.0'

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -52,7 +52,7 @@ module ConsulCookbook
       attribute(:acl_token, kind_of: String, default: lazy { node['consul']['config']['acl_master_token'] })
 
       def command
-        "#{program} agent -config-file=#{config_file} -config-dir=#{config_dir}"
+        "#{program} agent -config-file=#{config_file} -config-dir=#{config_dir} -advertise=#{node['ipaddress']}"
       end
 
       def shell_environment

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '3.0.1'
+version '3.0.2'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'


### PR DESCRIPTION
Add new 3.0.2 version that explicitly sets the advertise ip to the chef-detected primary to allow for compatibility with additional interfaces (like docker's bridge interface).